### PR TITLE
🐛 Fix - Virtual Web Server Unnecessary Status

### DIFF
--- a/virtual-web-server/src/main/java/org/dongguk/mlac/dto/type/EOrganizer.java
+++ b/virtual-web-server/src/main/java/org/dongguk/mlac/dto/type/EOrganizer.java
@@ -29,6 +29,6 @@ public enum EOrganizer {
         return Arrays.stream(EOrganizer.values())
                 .filter(organizer -> organizer.getValue().equals(attack.toString()))
                 .findFirst()
-                .orElse(EOrganizer.OBSERVING_SYSTEM);
+                .orElse(null);
     }
 }


### PR DESCRIPTION
## Issue
You need to link it to the index specifying which issue you addressed.

- Resolves : #60
 
## What To Do
You should present a list of what you've done in the corresponding pull request.

- Virtual Web Server의 Organizer Status에서 존재하지 않는 Status를 제거합니다.
